### PR TITLE
Closes #16

### DIFF
--- a/task_3/script.js
+++ b/task_3/script.js
@@ -25,8 +25,11 @@ function createImageElement(src) {
     saveGallery();
   });
 
+  // Error handler for image loading
   img.onerror = () => {
     img.src = "fallback-image.jpg"; // Placeholder for broken images
+    img.alt = "Image not available"; // Update alt text to indicate error
+    alert("The image could not be loaded. A placeholder image has been shown."); // Notify user about the broken image
   };
 
   return img;


### PR DESCRIPTION
-Added alert for image loading failure:
When an image fails to load, the img.onerror event handler is triggered. It now shows an alert message to the user: alert("The image could not be loaded. A placeholder image has been shown."). This gives feedback to the user that there was an issue with the image.

-Updated alt text:
The alt text for the image is updated to "Image not available" when the image fails to load. This helps improve accessibility and provides context when the image is not available.

-Fallback image is set:
The img.src = "fallback-image.jpg" remains as a fallback, so a placeholder image will appear instead of the broken image.